### PR TITLE
RxSwift / RxCocoa update to 5.1.1 / Deployment Target to 10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+.DS_Store

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }
   s.exclude_files = "tests/**/*"
   s.platform      = :ios
-  s.ios.deployment_target = "12.0"
+  s.ios.deployment_target = "10.0"
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
   s.default_subspec = "Core"
   s.swift_versions = ['4.2', '5.0']

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.15.1"
+  s.version       = "0.16.0"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }
   s.exclude_files = "tests/**/*"
   s.platform      = :ios
-  s.ios.deployment_target = "10.0"
+  s.ios.deployment_target = "12.0"
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
   s.default_subspec = "Core"
   s.swift_versions = ['4.2', '5.0']
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Rx" do |rx|
     rx.source_files = "SwiftWisdom/Rx/**/**/*.swift"
-    rx.dependency 'RxSwift', '~> 4.5'
-    rx.dependency 'RxCocoa', '~> 4.5'
+    rx.dependency 'RxSwift', '~> 5.1.1'
+    rx.dependency 'RxCocoa', '~> 5.1.1'
   end
 end

--- a/IntrepidTesting.podspec
+++ b/IntrepidTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "IntrepidTesting"
-  s.version       = "0.10.0"
+  s.version       = "0.11.0"
   s.summary       = "A collection of test extensions to the Swift Standard Library"
   s.description   = <<-DESC
                     Collection of test extensions and utility classes by and for the developers at Intrepid Pursuits.
@@ -10,11 +10,11 @@ Pod::Spec.new do |s|
   s.authors       = { "Colden Prime" => "colden@intrepid.io" }
   s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }
   s.platform      = :ios
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "12.0"
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
   s.default_subspec = "Core"
   s.swift_versions = ['4.2', '5.0']
-  
+
   s.subspec "Core" do |cs|
     cs.frameworks    = "XCTest"
     cs.source_files  = "SwiftWisdomTests/Testing/**/*.swift"

--- a/IntrepidTesting.podspec
+++ b/IntrepidTesting.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors       = { "Colden Prime" => "colden@intrepid.io" }
   s.source        = { :git => "https://github.com/IntrepidPursuits/swift-wisdom.git", :tag => "#{s.version}" }
   s.platform      = :ios
-  s.ios.deployment_target = "12.0"
+  s.ios.deployment_target = "10.0"
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
   s.default_subspec = "Core"
   s.swift_versions = ['4.2', '5.0']

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs'
 
-platform :ios, '12.0'
+platform :ios, '10.0'
 
 use_frameworks!
 inhibit_all_warnings!

--- a/Podfile
+++ b/Podfile
@@ -1,14 +1,16 @@
 source 'https://github.com/CocoaPods/Specs'
 
-platform :ios, '9.0'
+platform :ios, '12.0'
 
 use_frameworks!
 inhibit_all_warnings!
 
 def commonpods
   pod 'IP-UIKit-Wisdom'
-    pod 'RxSwift', '~> 4.5'
-    pod 'RxCocoa', '~> 4.5'
+  pod 'RxSwift', '~> 5.1.1'
+  pod 'RxCocoa', '~> 5.1.1'
+
+  pod 'SwiftLint', '~> 0.40.0'
 end
 
 target 'SwiftWisdom' do
@@ -17,7 +19,7 @@ end
 
 target 'SwiftWisdomTests' do
   commonpods()
-  pod 'RxTest', '~> 4.5'
+  pod 'RxTest', '~> 5.1.1'
 end
 
 post_install do |installer|

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,30 +1,39 @@
 PODS:
   - IP-UIKit-Wisdom (0.0.10)
-  - RxCocoa (4.5.0):
-    - RxSwift (>= 4.4.2, ~> 4.4)
-  - RxSwift (4.5.0)
-  - RxTest (4.5.0):
-    - RxSwift (>= 4.4.2, ~> 4.4)
+  - RxCocoa (5.1.1):
+    - RxRelay (~> 5)
+    - RxSwift (~> 5)
+  - RxRelay (5.1.1):
+    - RxSwift (~> 5)
+  - RxSwift (5.1.1)
+  - RxTest (5.1.1):
+    - RxSwift (~> 5)
+  - SwiftLint (0.40.0)
 
 DEPENDENCIES:
   - IP-UIKit-Wisdom
-  - RxCocoa (~> 4.5)
-  - RxSwift (~> 4.5)
-  - RxTest (~> 4.5)
+  - RxCocoa (~> 5.1.1)
+  - RxSwift (~> 5.1.1)
+  - RxTest (~> 5.1.1)
+  - SwiftLint (~> 0.40.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - IP-UIKit-Wisdom
     - RxCocoa
+    - RxRelay
     - RxSwift
     - RxTest
+    - SwiftLint
 
 SPEC CHECKSUMS:
   IP-UIKit-Wisdom: b395a065344071b33659e5f6b918043a97c48a44
-  RxCocoa: cbf70265dc65a981d4ac982e513c10cf23df24a0
-  RxSwift: f172070dfd1a93d70a9ab97a5a01166206e1c575
-  RxTest: 3ccb66bfbace0bf7df1c43a7c75d046f8ce60372
+  RxCocoa: 32065309a38d29b5b0db858819b5bf9ef038b601
+  RxRelay: d77f7d771495f43c556cbc43eebd1bb54d01e8e9
+  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
+  RxTest: 711632d5644dffbeb62c936a521b5b008a1e1faa
+  SwiftLint: 4154893c73a4c52d6240195507eb7a3e3c64087e
 
-PODFILE CHECKSUM: afd51654925ed213b6b02f072f7fa09392e041f0
+PODFILE CHECKSUM: 0b3531c5beefee7d976b641bf2b0ce80f252be63
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.9.3

--- a/SwiftWisdom.xcodeproj/project.pbxproj
+++ b/SwiftWisdom.xcodeproj/project.pbxproj
@@ -906,7 +906,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    if [ -e Pods/SwiftLint/swiftlint ]; then\n        Pods/SwiftLint/swiftlint\n    else \n        echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n    fi\nfi\n";
 		};
 		6F1F6BD10F68CC6443D86CE4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/SwiftWisdom.xcodeproj/project.pbxproj
+++ b/SwiftWisdom.xcodeproj/project.pbxproj
@@ -935,12 +935,14 @@
 				"${PODS_ROOT}/Target Support Files/Pods-SwiftWisdom/Pods-SwiftWisdom-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/IP-UIKit-Wisdom/IP_UIKit_Wisdom.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxRelay/RxRelay.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IP_UIKit_Wisdom.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -975,6 +977,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-SwiftWisdomTests/Pods-SwiftWisdomTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/IP-UIKit-Wisdom/IP_UIKit_Wisdom.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxRelay/RxRelay.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/RxTest/RxTest.framework",
 			);
@@ -982,6 +985,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IP_UIKit_Wisdom.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxTest.framework",
 			);

--- a/SwiftWisdom.xcodeproj/xcshareddata/xcschemes/SwiftWisdom.xcscheme
+++ b/SwiftWisdom.xcodeproj/xcshareddata/xcschemes/SwiftWisdom.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "80232B9E1BF2EE2E00818B6E"
+            BuildableName = "SwiftWisdom.app"
+            BlueprintName = "SwiftWisdom"
+            ReferencedContainer = "container:SwiftWisdom.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "80232B9E1BF2EE2E00818B6E"
-            BuildableName = "SwiftWisdom.app"
-            BlueprintName = "SwiftWisdom"
-            ReferencedContainer = "container:SwiftWisdom.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -72,8 +70,6 @@
             ReferencedContainer = "container:SwiftWisdom.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftWisdom/Core/Foundation/Not.swift
+++ b/SwiftWisdom/Core/Foundation/Not.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Intrepid. All rights reserved.
 //
 
-/**
+/*
  Inverts a given boolean closure
  
       let newNames = ["Joe", "Betty"].filter(!existingNames.contains)

--- a/SwiftWisdom/Rx/Rx+DelayElements.swift
+++ b/SwiftWisdom/Rx/Rx+DelayElements.swift
@@ -22,10 +22,10 @@ extension ObservableType {
      - returns: New observable sequence as described.
      */
     public func ip_delayElements(
-            matching predicate: @escaping (E) -> Bool,
-            by delayTime: RxTimeInterval,
-            scheduler: SchedulerType = MainScheduler.instance
-        ) -> Observable<E> {
+        matching predicate: @escaping (Element) -> Bool,
+        by delayTime: RxTimeInterval,
+        scheduler: SchedulerType = MainScheduler.instance
+    ) -> Observable<Element> {
         return
             Observable.of(
                 filter(predicate).delay(delayTime, scheduler: scheduler),

--- a/SwiftWisdom/Rx/Rx+Extensions.swift
+++ b/SwiftWisdom/Rx/Rx+Extensions.swift
@@ -41,29 +41,9 @@ public func <- <T: ObserverType, O>(observer: T, variable: O) -> Disposable wher
     return observer <- BehaviorRelay(value: variable)
 }
 
-//public func <- <T, O: ObservableType>(variable: T, observable: O) -> Disposable where O.Element == T {
-//    return variable <- observable.asObservable()
-//}
-
 public func <- <T>(observer: BehaviorRelay<T>, observable: BehaviorRelay<T>) -> Disposable {
     return observer <- observable.asObservable()
 }
-
-//public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.Element == O {
-//    return observer <- variable.asObservable()
-//}
-//
-//public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.Element == O? {
-//    return observer <- variable.asObservable()
-//}
-//
-//public func <- <T, O: ObservableType>(variable: Variable<T>, observable: O) -> Disposable where O.Element == T {
-//    return observable.bind(to: variable)
-//}
-//
-//public func <- <T>(observer: Variable<T>, observable: Variable<T>) -> Disposable {
-//    return observer <- observable.asObservable()
-//}
 
 public func <- <T: ObserverType, O>(observer: T, behaviorRelay: BehaviorRelay<O>) -> Disposable where T.Element == O {
     return observer <- behaviorRelay.asObservable()
@@ -76,10 +56,6 @@ public func <- <T: ObserverType, O>(observer: T, behaviorRelay: BehaviorRelay<O>
 public func <- <T, O: ObservableType>(behaviorRelay: BehaviorRelay<T>, observable: O) -> Disposable where O.Element == T {
     return observable.bind(to: behaviorRelay)
 }
-
-//public func <- <T>(observer: BehaviorRelay<T>, observable: BehaviorRelay<T>) -> Disposable {
-//    return observer <- observable.asObservable()
-//}
 
 public func >>> (disposable: Disposable, disposeBag: DisposeBag) {
     disposeBag.insert(disposable)
@@ -95,23 +71,6 @@ public func >>> (disposable: Disposable, compositeDisposable: CompositeDisposabl
 //  Created by Krunoslav Zaher on 12/6/15.
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //  https://github.com/ReactiveX/RxSwift/blob/master/RxExample/RxExample/Operators.swift
-//public func <-> <T>(property: ControlProperty<T>, variable: Variable<T>) -> Disposable {
-//    let bindToUIDisposable = variable
-//        .asObservable()
-//        .bind(to: property)
-//    let bindToVariable = property
-//        .subscribe(
-//            onNext: { next in
-//                variable.value = next
-//            },
-//            onCompleted: {
-//                bindToUIDisposable.dispose()
-//            }
-//    )
-//
-//    return Disposables.create(bindToUIDisposable, bindToVariable)
-//}
-
 public func <-> <T>(property: ControlProperty<T>, behaviorRelay: BehaviorRelay<T>) -> Disposable {
     let bindToUIDisposable = behaviorRelay
         .asObservable()

--- a/SwiftWisdom/Rx/Rx+Extensions.swift
+++ b/SwiftWisdom/Rx/Rx+Extensions.swift
@@ -25,45 +25,61 @@ infix operator <-> : Binding
 infix operator <- : Binding
 infix operator >>> : Disposing
 
-public func <- <T: ObserverType, O: ObservableType>(observer: T, observable: O) -> Disposable where T.E == O.E {
+public func <- <T: ObserverType, O: ObservableType>(observer: T, observable: O) -> Disposable where T.Element == O.Element {
     return observable.observeOn(MainScheduler.instance).bind(to: observer)
 }
 
-public func <- <T: ObserverType, O: ObservableType>(observer: T, observable: O) -> Disposable where T.E == O.E? {
+public func <- <T: ObserverType, O: ObservableType>(observer: T, observable: O) -> Disposable where T.Element == O.Element? {
     return observable.observeOn(MainScheduler.instance).bind(to: observer)
 }
 
-public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.E == O {
-    return observer <- variable.asObservable()
+public func <- <T: ObserverType, O>(observer: T, variable: O) -> Disposable where T.Element == O {
+    return observer <- BehaviorRelay(value: variable)
 }
 
-public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.E == O? {
-    return observer <- variable.asObservable()
+public func <- <T: ObserverType, O>(observer: T, variable: O) -> Disposable where T.Element == O? {
+    return observer <- BehaviorRelay(value: variable)
 }
 
-public func <- <T, O: ObservableType>(variable: Variable<T>, observable: O) -> Disposable where O.E == T {
-    return observable.bind(to: variable)
-}
-
-public func <- <T>(observer: Variable<T>, observable: Variable<T>) -> Disposable {
-    return observer <- observable.asObservable()
-}
-
-public func <- <T: ObserverType, O>(observer: T, behaviorRelay: BehaviorRelay<O>) -> Disposable where T.E == O {
-    return observer <- behaviorRelay.asObservable()
-}
-
-public func <- <T: ObserverType, O>(observer: T, behaviorRelay: BehaviorRelay<O>) -> Disposable where T.E == O? {
-    return observer <- behaviorRelay.asObservable()
-}
-
-public func <- <T, O: ObservableType>(behaviorRelay: BehaviorRelay<T>, observable: O) -> Disposable where O.E == T {
-    return observable.bind(to: behaviorRelay)
-}
+//public func <- <T, O: ObservableType>(variable: T, observable: O) -> Disposable where O.Element == T {
+//    return variable <- observable.asObservable()
+//}
 
 public func <- <T>(observer: BehaviorRelay<T>, observable: BehaviorRelay<T>) -> Disposable {
     return observer <- observable.asObservable()
 }
+
+//public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.Element == O {
+//    return observer <- variable.asObservable()
+//}
+//
+//public func <- <T: ObserverType, O>(observer: T, variable: Variable<O>) -> Disposable where T.Element == O? {
+//    return observer <- variable.asObservable()
+//}
+//
+//public func <- <T, O: ObservableType>(variable: Variable<T>, observable: O) -> Disposable where O.Element == T {
+//    return observable.bind(to: variable)
+//}
+//
+//public func <- <T>(observer: Variable<T>, observable: Variable<T>) -> Disposable {
+//    return observer <- observable.asObservable()
+//}
+
+public func <- <T: ObserverType, O>(observer: T, behaviorRelay: BehaviorRelay<O>) -> Disposable where T.Element == O {
+    return observer <- behaviorRelay.asObservable()
+}
+
+public func <- <T: ObserverType, O>(observer: T, behaviorRelay: BehaviorRelay<O>) -> Disposable where T.Element == O? {
+    return observer <- behaviorRelay.asObservable()
+}
+
+public func <- <T, O: ObservableType>(behaviorRelay: BehaviorRelay<T>, observable: O) -> Disposable where O.Element == T {
+    return observable.bind(to: behaviorRelay)
+}
+
+//public func <- <T>(observer: BehaviorRelay<T>, observable: BehaviorRelay<T>) -> Disposable {
+//    return observer <- observable.asObservable()
+//}
 
 public func >>> (disposable: Disposable, disposeBag: DisposeBag) {
     disposeBag.insert(disposable)
@@ -79,22 +95,22 @@ public func >>> (disposable: Disposable, compositeDisposable: CompositeDisposabl
 //  Created by Krunoslav Zaher on 12/6/15.
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //  https://github.com/ReactiveX/RxSwift/blob/master/RxExample/RxExample/Operators.swift
-public func <-> <T>(property: ControlProperty<T>, variable: Variable<T>) -> Disposable {
-    let bindToUIDisposable = variable
-        .asObservable()
-        .bind(to: property)
-    let bindToVariable = property
-        .subscribe(
-            onNext: { next in
-                variable.value = next
-            },
-            onCompleted: {
-                bindToUIDisposable.dispose()
-            }
-    )
-
-    return Disposables.create(bindToUIDisposable, bindToVariable)
-}
+//public func <-> <T>(property: ControlProperty<T>, variable: Variable<T>) -> Disposable {
+//    let bindToUIDisposable = variable
+//        .asObservable()
+//        .bind(to: property)
+//    let bindToVariable = property
+//        .subscribe(
+//            onNext: { next in
+//                variable.value = next
+//            },
+//            onCompleted: {
+//                bindToUIDisposable.dispose()
+//            }
+//    )
+//
+//    return Disposables.create(bindToUIDisposable, bindToVariable)
+//}
 
 public func <-> <T>(property: ControlProperty<T>, behaviorRelay: BehaviorRelay<T>) -> Disposable {
     let bindToUIDisposable = behaviorRelay
@@ -114,7 +130,7 @@ public func <-> <T>(property: ControlProperty<T>, behaviorRelay: BehaviorRelay<T
 
 extension ObservableType {
     /// This function just exists to enable use of the trailing closure.
-    public func subscribeNext(_ on: @escaping (E) -> Swift.Void) -> Disposable {
+    public func subscribeNext(_ on: @escaping (Element) -> Swift.Void) -> Disposable {
         return subscribe(onNext: on)
     }
 }

--- a/SwiftWisdom/Rx/Rx+RepeatingTimeouts.swift
+++ b/SwiftWisdom/Rx/Rx+RepeatingTimeouts.swift
@@ -25,9 +25,9 @@ extension ObservableType {
      */
     public func ip_repeatingTimeouts(
             interval dueTime: RxTimeInterval,
-            element: E,
+            element: Element,
             scheduler: SchedulerType = MainScheduler.instance
-        ) -> Observable<E> {
+    ) -> Observable<Element> {
         return
             Observable.of(
                 asObservable(),

--- a/SwiftWisdomTests/Rx/Rx+DelayElementsTests.swift
+++ b/SwiftWisdomTests/Rx/Rx+DelayElementsTests.swift
@@ -18,11 +18,11 @@ final class RxDelayElementsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observable =
             scheduler.createColdObservable([
-                next(0, 0),
-                next(1, 1),
-                next(2, 2),
-                next(3, 3),
-                next(4, 4)
+                Recorded.next(0, 0),
+                Recorded.next(1, 1),
+                Recorded.next(2, 2),
+                Recorded.next(3, 3),
+                Recorded.next(4, 4)
             ])
             .ip_delayElements(
                 matching: { $0 >= 2 },
@@ -50,11 +50,11 @@ final class RxDelayElementsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observable =
             scheduler.createColdObservable([
-                next(0, 0),
-                next(1, 1),
-                next(2, 2),
-                next(3, 3),
-                next(4, 4)
+                Recorded.next(0, 0),
+                Recorded.next(1, 1),
+                Recorded.next(2, 2),
+                Recorded.next(3, 3),
+                Recorded.next(4, 4)
             ])
             .ip_delayElements(
                 matching: { $0 % 2 == 0 },

--- a/SwiftWisdomTests/Rx/Rx+DelayElementsTests.swift
+++ b/SwiftWisdomTests/Rx/Rx+DelayElementsTests.swift
@@ -26,7 +26,7 @@ final class RxDelayElementsTests: XCTestCase {
             ])
             .ip_delayElements(
                 matching: { $0 >= 2 },
-                by: 2,
+                by: .seconds(2),
                 scheduler: scheduler
             )
         let observer = scheduler.createObserver(Int.self)
@@ -58,7 +58,7 @@ final class RxDelayElementsTests: XCTestCase {
             ])
             .ip_delayElements(
                 matching: { $0 % 2 == 0 },
-                by: 2,
+                by: .seconds(2),
                 scheduler: scheduler
             )
         let observer = scheduler.createObserver(Int.self)

--- a/SwiftWisdomTests/Rx/Rx+ExtensionsTest.swift
+++ b/SwiftWisdomTests/Rx/Rx+ExtensionsTest.swift
@@ -6,30 +6,30 @@ import RxCocoa
 
 class OperatorTests: XCTestCase {
 
-    func testVariableBinding() {
+    func testBehaviorRelayBinding() {
         let disposeBag = DisposeBag()
         let label = UILabel()
-        let variable = BehaviorRelay<String?>(value: nil)
+        let relay = BehaviorRelay<String?>(value: nil)
 
-        label.rx.text <- variable >>> disposeBag
+        label.rx.text <- relay >>> disposeBag
         XCTAssertEqual(nil, label.text)
 
-        variable.accept("hello")
+        relay.accept("hello")
         XCTAssertEqual("hello", label.text)
 
-        variable.accept(nil)
+        relay.accept(nil)
         XCTAssertEqual(nil, label.text)
     }
 
-    func testNonOptionalVariableBindingToOptionalObserver() {
+    func testNonOptionalBehaviorRelayBindingToOptionalObserver() {
         let disposeBag = DisposeBag()
         let label = UILabel()
-        let variable = BehaviorRelay<String>(value: "")
+        let relay = BehaviorRelay<String>(value: "")
 
-        label.rx.text <- variable >>> disposeBag
+        label.rx.text <- relay >>> disposeBag
         XCTAssertEqual("", label.text)
 
-        variable.accept("hello")
+        relay.accept("hello")
         XCTAssertEqual("hello", label.text)
     }
 
@@ -42,52 +42,12 @@ class OperatorTests: XCTestCase {
         XCTAssertEqual("hello", button.title(for: .normal))
     }
 
-    func testBindingToVariable() {
-        let disposeBag = DisposeBag()
-        let sut = BehaviorRelay<String>(value: "")
-        let variable = BehaviorRelay<String>(value: "hello")
-
-        sut <- variable >>> disposeBag
-        XCTAssertEqual(variable.value, sut.value)
-        XCTAssertEqual("hello", sut.value)
-
-        variable.accept("world")
-        XCTAssertEqual(variable.value, sut.value)
-    }
-
     func testAddCompositeDisposable() {
         let compositeDisposable = CompositeDisposable()
         let observable = Observable<String?>.never()
         XCTAssertEqual(0, compositeDisposable.count)
         UILabel().rx.text <- observable >>> compositeDisposable
         XCTAssertEqual(1, compositeDisposable.count)
-    }
-    
-    func testBehaviorRelayBinding() {
-        let disposeBag = DisposeBag()
-        let label = UILabel()
-        let behaviorRelay = BehaviorRelay<String?>(value: nil)
-        
-        label.rx.text <- behaviorRelay >>> disposeBag
-        XCTAssertEqual(nil, label.text)
-        
-        behaviorRelay.accept("hello")
-        XCTAssertEqual("hello", label.text)
-        
-        behaviorRelay.accept(nil)
-        XCTAssertEqual(nil, label.text)
-    }
-    
-    func testNonOptionalBehaviorRelayBindingToOptionalObserver() {
-        let disposeBag = DisposeBag()
-        let label = UILabel()
-        let behaviorRelay = BehaviorRelay<String>(value: "")
-
-        label.rx.text <- behaviorRelay >>> disposeBag
-        XCTAssertEqual("", label.text)
-        
-        behaviorRelay.accept("hello")
-        XCTAssertEqual("hello", label.text)
     }
     
     func testBindingToBehaviorRelay() {
@@ -115,20 +75,6 @@ class OperatorTests: XCTestCase {
         textField.text = "world"
         textField.sendActions(for: .editingChanged)
         XCTAssertEqual("world", behaviorRelay.value)
-    }
-    
-    func testTwoWayBindingWithVariable() {
-        let disposeBag = DisposeBag()
-        let textField = UITextField()
-        let variable = BehaviorRelay<String?>(value: nil)
-        
-        textField.rx.text <-> variable >>> disposeBag
-        variable.accept("hello")
-        XCTAssertEqual("hello", textField.text)
-        
-        textField.text = "world"
-        textField.sendActions(for: .editingChanged)
-        XCTAssertEqual("world", variable.value)
     }
 
 }

--- a/SwiftWisdomTests/Rx/Rx+ExtensionsTest.swift
+++ b/SwiftWisdomTests/Rx/Rx+ExtensionsTest.swift
@@ -9,27 +9,27 @@ class OperatorTests: XCTestCase {
     func testVariableBinding() {
         let disposeBag = DisposeBag()
         let label = UILabel()
-        let variable = Variable<String?>(nil)
+        let variable = BehaviorRelay<String?>(value: nil)
 
         label.rx.text <- variable >>> disposeBag
         XCTAssertEqual(nil, label.text)
 
-        variable.value = "hello"
+        variable.accept("hello")
         XCTAssertEqual("hello", label.text)
 
-        variable.value = nil
+        variable.accept(nil)
         XCTAssertEqual(nil, label.text)
     }
 
     func testNonOptionalVariableBindingToOptionalObserver() {
         let disposeBag = DisposeBag()
         let label = UILabel()
-        let variable = Variable<String>("")
+        let variable = BehaviorRelay<String>(value: "")
 
         label.rx.text <- variable >>> disposeBag
         XCTAssertEqual("", label.text)
 
-        variable.value = "hello"
+        variable.accept("hello")
         XCTAssertEqual("hello", label.text)
     }
 
@@ -44,14 +44,14 @@ class OperatorTests: XCTestCase {
 
     func testBindingToVariable() {
         let disposeBag = DisposeBag()
-        let sut = Variable<String>("")
-        let variable = Variable<String>("hello")
+        let sut = BehaviorRelay<String>(value: "")
+        let variable = BehaviorRelay<String>(value: "hello")
 
         sut <- variable >>> disposeBag
         XCTAssertEqual(variable.value, sut.value)
         XCTAssertEqual("hello", sut.value)
 
-        variable.value = "world"
+        variable.accept("world")
         XCTAssertEqual(variable.value, sut.value)
     }
 
@@ -120,10 +120,10 @@ class OperatorTests: XCTestCase {
     func testTwoWayBindingWithVariable() {
         let disposeBag = DisposeBag()
         let textField = UITextField()
-        let variable = Variable<String?>(nil)
+        let variable = BehaviorRelay<String?>(value: nil)
         
         textField.rx.text <-> variable >>> disposeBag
-        variable.value = "hello"
+        variable.accept("hello")
         XCTAssertEqual("hello", textField.text)
         
         textField.text = "world"

--- a/SwiftWisdomTests/Rx/Rx+RepeatingTimeoutsTests.swift
+++ b/SwiftWisdomTests/Rx/Rx+RepeatingTimeoutsTests.swift
@@ -29,7 +29,7 @@ final class RxRepeatingTimeoutsTests: XCTestCase {
                 next(16, .element)
             ])
             .ip_repeatingTimeouts(
-                interval: 5,
+                interval: .seconds(5),
                 element: .timeout,
                 scheduler: scheduler
             )

--- a/SwiftWisdomTests/Rx/Rx+RepeatingTimeoutsTests.swift
+++ b/SwiftWisdomTests/Rx/Rx+RepeatingTimeoutsTests.swift
@@ -23,10 +23,10 @@ final class RxRepeatingTimeoutsTests: XCTestCase {
         let scheduler = TestScheduler(initialClock: 0)
         let observable: Observable<TestElement> =
             scheduler.createColdObservable([
-                next(8, .element),
-                next(9, .element),
-                next(15, .element),
-                next(16, .element)
+                Recorded.next(8, .element),
+                Recorded.next(9, .element),
+                Recorded.next(15, .element),
+                Recorded.next(16, .element)
             ])
             .ip_repeatingTimeouts(
                 interval: .seconds(5),


### PR DESCRIPTION
Got a warning from Apple that new app submissions will not be allowed to access UIWebView at all, and existing apps will not be able to submit new versions which access the UIWebView API starting in December 2020.

RxCocoa version 4.5 has a few extensions to UIWebView, and it seems like those extensions trigger the Apple check.

This pull request does several things:

* Update RxSwift / RxCocoa to version 5.1.1
* Add SwiftLint into the Podfile so it can be loaded locally
* Update SwiftLint build step for sample app to run first locally, then globally, then complain to user about missing SwiftLint
* Fixed SwiftLint orphaned_doc_comment warning
* Fix a BUNCH of RxSwift errors:
 ** 'Variable' replaced with 'BehaviorRelay'
 ** 'E' replaced with 'Element'
 ** Errors around DispatchTimeInterval initialization no longer assuming seconds (i.e., "5" changed to ".seconds(5)")
 ** 'next' deprecated
* Updated Intrepid Podspec to 0.16.0, deployment target to iOS 12.0
* Updated IntrepidTesting Podspec to 0.11.0