### PR TITLE
[MONET-8445] Upgrading Rx libraries to 5.1.1

### DIFF
--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Rx" do |rx|
     rx.source_files = "SwiftWisdom/Rx/**/**/*.swift"
-    rx.dependency 'RxSwift', '~> 4.5'
-    rx.dependency 'RxCocoa', '~> 4.5'
+    rx.dependency 'RxSwift', '5.1.1'
+    rx.dependency 'RxCocoa', '5.1.1'
   end
 end

--- a/Intrepid.podspec
+++ b/Intrepid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "Intrepid"
-  s.version       = "0.15.1"
+  s.version       = "0.15.2"
   s.summary       = "Swift Bag"
   s.description   = <<-DESC
                     Collection of extensions and utility classes by and for the developers at Intrepid Pursuits.

--- a/Podfile
+++ b/Podfile
@@ -7,8 +7,8 @@ inhibit_all_warnings!
 
 def commonpods
   pod 'IP-UIKit-Wisdom'
-    pod 'RxSwift', '~> 4.5'
-    pod 'RxCocoa', '~> 4.5'
+    pod 'RxSwift', '5.1.1'
+    pod 'RxCocoa', '5.1.1'
 end
 
 target 'SwiftWisdom' do


### PR DESCRIPTION
- Apple Mandated that iOS code should not use UIWebView in future releases.
- Upgrade RxSwift and RxCocoa to 5.1.1 version as RxCocoa using UIWebView at one place.